### PR TITLE
fix(gh-icon): Don't use a slash at the begin of an url

### DIFF
--- a/src/demo-app/icon/icon-demo.ts
+++ b/src/demo-app/icon/icon-demo.ts
@@ -13,10 +13,10 @@ export class IconDemo {
   constructor(iconRegistry: GhIconRegistry, sanitizer: DomSanitizer) {
     iconRegistry
       .addSvgIcon('agent',
-        sanitizer.bypassSecurityTrustResourceUrl('/assets/agent.svg'))
+        sanitizer.bypassSecurityTrustResourceUrl('assets/agent.svg'))
       .addSvgIconInNamespace('core', 'sensor',
-        sanitizer.bypassSecurityTrustResourceUrl('/assets/sensor.svg'))
+        sanitizer.bypassSecurityTrustResourceUrl('assets/sensor.svg'))
       .addSvgIconInNamespace('core', 'ai',
-        sanitizer.bypassSecurityTrustResourceUrl('/assets/ai.svg'));
+        sanitizer.bypassSecurityTrustResourceUrl('assets/ai.svg'));
   }
 }

--- a/src/lib/icon/README.md
+++ b/src/lib/icon/README.md
@@ -26,11 +26,11 @@ export class IconDemo {
     iconRegistry
       // Registering an icon named 'agend' in the default namespace
       .addSvgIcon('agent',
-        sanitizer.bypassSecurityTrustResourceUrl('/assets/agent.svg'))
+        sanitizer.bypassSecurityTrustResourceUrl('assets/agent.svg'))
 
       // Registering an icon named 'ai' in the 'core namespace
       .addSvgIconInNamespace('core', 'ai',
-        sanitizer.bypassSecurityTrustResourceUrl('/assets/ai.svg'));
+        sanitizer.bypassSecurityTrustResourceUrl('assets/ai.svg'));
   }
 }
 ```


### PR DESCRIPTION
You should not use a slash at the begin of any URLs. The reason for that is, that if you change the base href of your application, this URLs won't work anymore. If you use no "/" and no "./" for a URL, the base href of your index.html will be used.

For example: 

`<base href="/services/dcm/">`

You can try this with the angluar-cli:

`ng serve --base-href /services/dcm/`

https://angular.io/guide/router#base-href

